### PR TITLE
Update SQLZOO_solutions.md

### DIFF
--- a/SQLZOO_solutions.md
+++ b/SQLZOO_solutions.md
@@ -319,7 +319,7 @@ SELECT continent, COUNT(name) FROM world
 ```sql
 SELECT continent FROM world
   GROUP BY continent
-  HAVING SUM(population) > 100000000
+  HAVING SUM(population) >= 100000000
 ```
 ## JOIN
 1.


### PR DESCRIPTION
In SUM and COUNT (excercise nr. 8) is missing an equal sign: 

SELECT continent 
FROM world
GROUP BY continent
HAVING SUM(population) >= 100000000