### PR TITLE
Corrects two faulty lines

### DIFF
--- a/SQLZOO_solutions.md
+++ b/SQLZOO_solutions.md
@@ -230,9 +230,9 @@ SELECT name, continent FROM world
 ```sql
 SELECT name, population FROM world
   WHERE population > (SELECT population FROM world
-                        WHERE name = 'Canada')
+                        WHERE name = 'United Kingdom')
     AND population < (SELECT population FROM world
-                        WHERE name = 'Poland')
+                        WHERE name = 'Germany')
 ```
 5.
 ```sql


### PR DESCRIPTION
In "SELECT within SELECT", the forth exercise expects "United Kingdom" and "Germany" instead of "Canada" and Poland".